### PR TITLE
 optional \begin{table}...\end{table} + Handling of  NA values in table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
-language: cpp
-compiler:
-  - clang
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - release
+  - nightly
 notifications:
   email: false
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/julianightlies -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-script:
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("YTables"))`); Pkg.pin("YTables"); Pkg.resolve()'
-  - julia -e 'using YTables; @assert isdefined(:YTables); @assert typeof(YTables) === Module'
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("YTables"); Pkg.test("ImputationQualityScores"; coverage=true)'
+after_success:
+  # push coverage results to Coveralls
+  - julia -e 'cd(Pkg.dir("YTables")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  # push coverage results to Codecov
+  - julia -e 'cd(Pkg.dir("YTables")); Pkg.add("YTables"); using Coverage; Codecov.submit(Codecov.process_folder())'
+

--- a/src/YTables.jl
+++ b/src/YTables.jl
@@ -12,6 +12,7 @@ abstract YStyle
 
 
 immutable LatexStyle <: YStyle
+    na::String
     embed_in_table::Bool
     tabular::String
     align::Dict{Symbol, String}
@@ -20,6 +21,7 @@ end
 
 
 immutable OrgStyle <: YStyle
+    na::String
 end
 
 
@@ -30,21 +32,22 @@ end
 
 
 ## constructors
-type_align(_::Number) = "r"
-type_align(_::String) = "l"
+#type_align(_::Number) = "r"
+#type_align(_::String) = "l"
+
+type_align{T<:Number}(_::DataArrays.DataArray{T,1}) = "r"
+type_align{T<:String}(_::DataArrays.DataArray{T,1}) = "l"
 
 
 make_align(data) =
-    Dict(n => type_align(data[1, n]) for n = names(data))
+    Dict(n => type_align(data[:, n]) for n = names(data))
 
-
-type_format(_::Integer) = v -> @sprintf("%d", v)
-type_format(_::Real)    = v -> @sprintf("%.2f", v)
-type_format(_::String)  = v -> @sprintf("%s", v)
-
+type_format{T<:Integer}(_::DataArrays.DataArray{T,1}) = v -> @sprintf("%d", v)
+type_format{T<:Real}(_::DataArrays.DataArray{T,1})    = v -> @sprintf("%.2f", v)
+type_format{T<:String}(_::DataArrays.DataArray{T,1})  = v -> @sprintf("%s", v)
 
 make_format(data) =
-    Dict(n => type_format(data[1, n]) for n in names(data))
+    Dict(n => type_format(data[:, n]) for n in names(data))
 
 
 formatter(f::String) =   @eval v -> @sprintf($f, v)
@@ -55,23 +58,24 @@ formatters(fs) =
     [formatter(v) for (k, v) = fs]
 
 
-latex(data; embed_in_table::Bool=true, tabular::String="tabular", alignment=Dict(), format=Dict()) =
-    YTable(data, LatexStyle(embed_in_table,
+latex(data; embed_in_table::Bool=true, tabular::String="tabular",na::String="-",alignment=Dict(), format=Dict()) =
+    YTable(data, LatexStyle(na,
+                            embed_in_table,
                             tabular,
                             merge(make_align(data), alignment),
                             merge(make_format(data), format)))
 
 
-org(data) = YTable(data, OrgStyle())
+org(data ; na::String="NA") = YTable(data, OrgStyle(na))
 
 
 ## printing
-format_row(row, format::Dict{Symbol, Function}) =
-    [string(format[n](row[n])) for n in names(row)]
+format_row(row, format::Dict{Symbol, Function}, na::String) =
+    [string(isna(row[n]) ? na : format[n](row[n])) for n in names(row)]
 
-function show_rows(io, data, format, pre, sep, post)
+function show_rows(io, data, format, na, pre, sep, post)
     for r = eachrow(data)
-        println(io, pre, join(format_row(r, format), sep), post)
+        println(io, pre, join(format_row(r, format, na), sep), post)
     end
 end
 
@@ -90,7 +94,7 @@ function show_table(io::IO, data::DataFrame, style::LatexStyle)
     println(io, "    \\hline")
     println(io, "    ", join(map(string, names(data)), " & "), " \\\\")
     println(io, "    \\hline")
-    show_rows(io, data, style.format, "    ", " & ", " \\\\")
+    show_rows(io, data, style.format, style.na, "    ", " & ", " \\\\")
     println(io, "    \\hline")
     println(io, "  \\end{tabular}")
     if style.embed_in_table
@@ -104,9 +108,9 @@ function show_table(io::IO, data::DataFrame, style::OrgStyle)
     widths = Dict(n => max(length(string(n)), vs[1]) for (n,vs) = eachcol(valwidths))
     format = Dict(n => formatter("%$v\s") for (n,v) = widths)
     ns = DataFrame(convert(Array{Any, 1}, [[n] for n in names(data)]), names(data))
-    show_rows(io, ns, format, "| ", " | ", " |")
+    show_rows(io, ns, format, style.na, "| ", " | ", " |")
     println(io, "|-", join([repeat("-", widths[n]) for n = names(data)], "-+-"), "-|")
-    show_rows(io, data, format, "| ", " | ", " |")
+    show_rows(io, data, format, style.na, "| ", " | ", " |")
 end
 
 

--- a/src/YTables.jl
+++ b/src/YTables.jl
@@ -69,15 +69,7 @@ const latex_escape_characters = Dict{String,String}(
 
 
 latex_escape(str::String) = join(map(c->(try latex_escape_characters[c] catch string(c) end),split(str,"")))
-no_escape(str::String) = str
 
-
-#latex(data; embed_in_table::Bool=true, tabular::String="tabular",na::String="-",alignment=Dict(), format=Dict()) =
-#    YTable(data, LatexStyle(na,
-#                            embed_in_table,
-#                            tabular,
-#                            merge(alignment,make_align(data)),
-#                            merge(format,make_format(data))))
 function latex(data; embed_in_table::Bool=true, tabular::String="tabular",na::String="-",escape::Bool=true,alignment=Dict(), format=Dict())
 
     if escape

--- a/src/YTables.jl
+++ b/src/YTables.jl
@@ -81,7 +81,7 @@ function latex(data; embed_in_table::Bool=true, tabular::String="tabular",na::St
     YTable(data, LatexStyle(na,
                             embed_in_table,
                             tabular,
-                            merge(alignment,make_align(data)),merge(format,deriv_format)))
+                            merge(make_align(data), alignment),merge(deriv_format,format)))
 end
 
 

--- a/src/YTables.jl
+++ b/src/YTables.jl
@@ -12,6 +12,7 @@ abstract YStyle
 
 
 immutable LatexStyle <: YStyle
+    embed_in_table::Bool
     tabular::String
     align::Dict{Symbol, String}
     format::Dict{Symbol, Function}
@@ -54,8 +55,9 @@ formatters(fs) =
     [formatter(v) for (k, v) = fs]
 
 
-latex(data; tabular::String="tabular", alignment=Dict(), format=Dict()) =
-    YTable(data, LatexStyle(tabular,
+latex(data; embed_in_table::Bool=true, tabular::String="tabular", alignment=Dict(), format=Dict()) =
+    YTable(data, LatexStyle(embed_in_table,
+                            tabular,
                             merge(make_align(data), alignment),
                             merge(make_format(data), format)))
 
@@ -79,8 +81,10 @@ function show_table(io::IO, data::DataFrame, style::LatexStyle)
                        VERSION, " by YTables"))
     println(io, string("% ", now()))
 
-    println(io, "\\begin{table}[ht]")
-    println(io, "  \\centering")
+    if style.embed_in_table
+        println(io, "\\begin{table}[ht]")
+        println(io, "  \\centering")
+    end
     as = [style.align[n] for n in names(data)]
     println(io, "  \\begin{", style.tabular, "}{", join(as), "}")
     println(io, "    \\hline")
@@ -89,7 +93,9 @@ function show_table(io::IO, data::DataFrame, style::LatexStyle)
     show_rows(io, data, style.format, "    ", " & ", " \\\\")
     println(io, "    \\hline")
     println(io, "  \\end{tabular}")
-    print(io, "\\end{table}")
+    if style.embed_in_table
+        print(io, "\\end{table}")
+    end
 end
 
 

--- a/src/YTables.jl
+++ b/src/YTables.jl
@@ -63,17 +63,30 @@ const latex_escape_characters = Dict{String,String}(
     "#" => "\\#",
     "{" => "\\{",
     "}" => "\\}",
+    ">" => "\\textgreater",
+    "<" => "\\textless",
     "~" => "\\textasciitilde",
     "^" => "\\textasciicircum",
     "\\" => "\\textasciibackslash")
 
 
 latex_escape(str::String) = join(map(c->(try latex_escape_characters[c] catch string(c) end),split(str,"")))
+latex_escape(sym::Symbol) = Symbol(latex_escape(string(sym)))
+
 
 function latex(data; embed_in_table::Bool=true, tabular::String="tabular",na::String="-",escape::Bool=true,alignment=Dict(), format=Dict())
 
     if escape
+	# Make copy of data frame so we can change names
+	data=copy(data)
+	for(name in names(data))
+		escname=latex_escape(name)
+		if name != escname 
+			rename!(data,name,escname)
+		end
+	end
         deriv_format = Dict(key=>v->latex_escape(value(v)) for (key,value) in make_format(data))
+	
     else
 	deriv_format = make_format(data)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,15 @@
+using Base.Test
+
+# Custom formatters: 
+@test ismatch(r"0.00 ", string(latex(DataFrame(a=[0.00101]))))
+@test ismatch(r"0.0010 ", string(latex(DataFrame(a=[0.00101]),format=Dict(:a => v-> @sprintf("%.4f", v)))))
+
+# No embed in table 
+@test ismatch(r"{table}", string(latex(DataFrame(a=[42]))))
+@test !ismatch(r"{table}", string(latex(DataFrame(a=[42]), embed_in_table=false)))
+
+# Handling of NA values in tables
+# This would fail before commit 7da7b2e 
+@test ismatch(r"0.00 ", string(latex(DataFrame(a=@data [0.00111111,NA]))))
+@test ismatch(r"0.00 ", string(latex(DataFrame(a=@data [NA,0.00111111])))) :
+


### PR DESCRIPTION
Thanks for writing YTables. It was (almost) just what I needed and the way you leverage Julias type system for the formatting was inspiring :+1:  

Commit https://github.com/farrellm/YTables.jl/commit/6a82eaf5df7432aea7cfdbade85dfcbc580f65a2 : 
I wanted to be able to output table for use with the longtable package. The existing named option `tabular` for the `latex` function is useful for this, but in addition longtable does not like a table around the longtable environment. Hence, I added a new named (boolean) option `embed_in_table` to `latex` which when it is false does not print the surrounding table (by default it is true). 

Commit https://github.com/farrellm/YTables.jl/commit/7da7b2eb87c0509aacbba612eacc0cabec756d8a :
The latex function fails when the data frame contains NA values. For two possible reasons: a) if the first row contains NA, the it does not infer a formatter. b) if a formatter function is inferred, it will break when called on an NA value. This commit fixes that. It adds a new option `na` to `latex` and `org` which is the 
string to be printed in place of NAs. 